### PR TITLE
Bypass use moving average

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,6 +11,7 @@ License: GPL 3.0
 Encoding: UTF-8
 LazyData: true
 Imports:
+    assertthat,
     curl,
     tidyverse,
     dplyr,

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -75,3 +75,5 @@ importFrom(tidyr,separate)
 importFrom(tidyr,gather)
 importFrom(tidyr,spread)
 importFrom(tidyr,replace_na)
+
+importFrom(assertthat, assert_that)

--- a/R/entsog_attribution.R
+++ b/R/entsog_attribution.R
@@ -1,3 +1,10 @@
+
+#' @title Redistribute flows for a period for each day
+#' @description Redistributes flows for a period for each day.
+#' @param flows_for_whole_period the flows for the whole period
+#' @return the flows for the period with the indirect imports distributed
+#' @rdname process_iterative
+#' @export
 process_iterative <- function(flows_for_whole_period) {
   process_with_date <- function(df) {
     process_iterative_for_day(df) %>%
@@ -13,7 +20,12 @@ process_iterative <- function(flows_for_whole_period) {
   return(flows_sourced)
 }
 
-# Approach: iterative + net flows
+#' @title Process iterative for day
+#' @description Processes flows for a single day using an iterative method.
+#' @param flows_for_day the flows for a single day
+#' @return the flows for the day with the indirect imports distributed
+#' @rdname process_iterative_for_day
+#' @export
 process_iterative_for_day <- function(flows_for_day) {
   options(dplyr.summarise.inform = FALSE)
 
@@ -22,52 +34,46 @@ process_iterative_for_day <- function(flows_for_day) {
        Please aggregate if need be.")
   }
 
-  # The flow_matrix contains the net imports for each country to each
-  # other country. The row of a matrix is the importer, the column of the
-  # matrix is the exporter. For example, flow_matrix["BG", "RU"] would give
-  # you the value of gas imported from Russia into Bulgaria).
-  flow_matrix <- build_flow_matrix(flows_for_day)
-
-  distributed_flows_for_day <- flow_matrix %>%
+  distributed_flows_for_day <- flows_for_day %>%
+    add_heuristics() %>%
+    build_flow_matrix() %>%
     distribute_until_stable() %>%
-    verify_matrix(original = flow_matrix) %>%
+    verify_matrix() %>%
     remove_production() %>%
     convert_to_data_frame()
 
   return(distributed_flows_for_day)
 }
 
-convert_to_data_frame <- function(flow_matrix) {
-  all_countries <- dimnames(flow_matrix)[[1]]
 
-  return(
-    bind_cols(country = sort(all_countries), as.data.frame(flow_matrix)) %>%
-      gather(key = "from_country", value = "value", -country) %>%
-      rename(to_country = country)
-  )
-}
-
-remove_production <- function(flow_matrix) {
-  diag(flow_matrix) <- 0
-  return(flow_matrix)
-}
-
+#' @title Build flow matrix
+#' @description Builds a flow matrix from a data frame of flows.
+#' @param flows The flows to build the matrix from in a data frame with columns
+#' from_country, to_country, value.
+#' @return
+#' A matrix which contains the net imports for each country to each other
+#' country. The row of a matrix is the importer, the column of the matrix is
+#' the exporter. For example, flow_matrix["BG", "RU"] would give you the value
+#' of gas imported from Russia into Bulgaria).
+#' @export
+#' @rdname build_flow_matrix
 build_flow_matrix <- function(flows) {
-  net_flows_matrix <- flows %>%
-    add_heuristics() %>%
-    consolidate() %>%
-    netize() %>%
-    to_flow_mat()
-
-  only_imports <- net_flows_matrix %>%
-    pmax(0) %>%
-    verify_matrix(original = net_flows_matrix)
-
   return(
-    only_imports
+    flows %>%
+      consolidate() %>%
+      netize() %>%
+      to_flow_mat() %>%
+      pmax(0) %>%
+      verify_matrix()
   )
 }
 
+#' @title Add heuristics
+#' @description Adds heuristics to flows.
+#' @param flows The flows to add heuristics to.
+#' @return The flows with heuristics added.
+#' @export
+#' @rdname add_heuristics
 add_heuristics <- function(flows) {
   return(
     flows %>%
@@ -82,19 +88,98 @@ add_heuristics <- function(flows) {
   )
 }
 
+#' @title Distribute until stable
+#' @description Distributes flows until they are stable.
+#' @param initial_matrix the matrix to distribute
+#' @return the distributed matrix
+#' @rdname distribute_until_stable
 distribute_until_stable <- function(initial_matrix) {
-  n_countries <- dim(initial_matrix)[1]
   current_matrix <- initial_matrix
+  prev_matrix <- NULL
 
-  for (ignored in seq(n_countries)) { # We don't need to use the iteration number, just iterate for n_countries.
-    current_matrix <- distribute(current_matrix)
-    if (!is_matrix_square(current_matrix)) {
-      stop("Matrix not square")
+  iteration_limit <- 1000
+  iteration_number <- 0
+
+  repeat {
+    prev_matrix <- current_matrix
+    current_matrix <- distribute(prev_matrix)
+
+    if (all(prev_matrix == current_matrix)) {
+      break
+    }
+    if ((iteration_number <- iteration_number + 1) >= iteration_limit) {
+      print(glue("WARNING: Iteration limit ({iteration_limit}) reached"))
+      break
     }
   }
   return(current_matrix)
 }
 
+#' @title Distribute flows
+#' @description
+#' Considering each country as an importer, we proportionally distribute
+#' the indirect imports of gas to each provider ("neighbours" of importers)
+#' from sub-providers ("neighbours" of providers) directly to the importer.
+#' @details
+#' When this function is called iteratively, on the first iteration, the
+#' "neighbours" will be the actual neighbours in the gas system but on
+#' future iterations, these will also include the sub-providers and then
+#' the sub-provider's sub-providers (and so on).
+#' @param flow_matrix the flow matrix to distribute
+#' @return the flow matrix with the indirect imports distributed
+#' @rdname distribute
+distribute <- function(flow_matrix) {
+  production_for_countries <- diag(flow_matrix)
+
+  countries <- rownames(flow_matrix)
+
+  for (importer in countries) {
+    importer_production <- get_production_matrix_for_country(flow_matrix, importer)
+
+    # We will iteratively modify this in the for loop.
+    aggregate_imports <- importer_production
+
+    for (provider in countries) {
+      if (importer == provider) {
+        next
+      }
+
+      provider_to_importer <- flow_matrix[importer, provider]
+
+      providers_imports <- flow_matrix[provider, ]
+      # Ukraine special case: Ukraine cannot reimport gas from Russia
+      if ((importer == "UA")) {
+        providers_imports["RU"] <- 0
+      }
+
+
+      subprovider_attribution <- if (sum(providers_imports) > 0) {
+        provider_to_importer * providers_imports / sum(providers_imports)
+      } else {
+        0
+      }
+
+      aggregate_imports <- aggregate_imports + subprovider_attribution
+      # What was added needs to be removed, sort of
+      # by passing the original
+      flow_matrix[provider, ] <- flow_matrix[provider, ] - subprovider_attribution
+      flow_matrix[provider, provider] <- production_for_countries[provider]
+    }
+
+    flow_matrix[importer, ] <- aggregate_imports
+  }
+
+  return(flow_matrix)
+}
+
+#' @title Set transit country
+#' @description Makes all flows to or from a transit country to or from the
+#' origin country.
+#' @param flows the flows to modify
+#' @param origin_country the country to set as the origin
+#' @param transit_country the transit country to override
+#' @return the flows with the transit country overridden
+#' @rdname set_transit_country
 set_transit_country <- function(flows, origin_country, transit_country) {
   flows %>%
     mutate(
@@ -113,6 +198,13 @@ set_transit_country <- function(flows, origin_country, transit_country) {
     )
 }
 
+#' @title Bypass country
+#' @description Bypasses a country by taking the flows from origin_iso2 to
+#' transit_iso2 and then from transit_iso2 to destination_iso2s and
+#' redistributing them so that the flows go from origin_iso2 to
+#' destination_iso2s, proportionally.
+#' @details If there is more input than output, then the excess will be left in
+#' the transit_iso2. If there is more output than input
 bypass_country <- function(flows, origin_iso2, transit_iso2, destination_iso2s) {
   if (length(unique(flows$date)) > 1) {
     stop("Only works for a single date")
@@ -166,8 +258,12 @@ bypass_country <- function(flows, origin_iso2, transit_iso2, destination_iso2s) 
   return(flows)
 }
 
-# Ensure all countries are both in from_country and to_country
-# so as to have a square matrix
+#' @title Consolidate
+#' @description Consolidates a flow matrix so that all countries are both in
+#' from_country and to_country.
+#' @param flow_matrix the flow matrix to consolidate
+#' @return the flow matrix with all countries in from_country and to_country
+#' @rdname consolidate
 consolidate <- function(flow_matrix) {
   all_countries <- unique(c(flow_matrix$from_country, flow_matrix$to_country))
   if (is.null(flow_matrix)) {
@@ -184,12 +280,17 @@ consolidate <- function(flow_matrix) {
     mutate(value = replace_na(value, 0))
 }
 
-to_flow_mat <- function(d) {
-  flows <- d %>%
+#' @title To flow matrix
+#' @description Converts a data frame of flows to a flow matrix.
+#' @param flows the flows to convert
+#' @return a flow matrix
+#' @rdname to_flow_mat
+to_flow_mat <- function(flows) {
+  flows <- flows %>%
     group_by(country = to_country, partner = from_country) %>%
     summarise(import = sum(value, na.rm = T)) %>%
     left_join(
-      d %>%
+      flows %>%
         group_by(country = from_country, partner = to_country) %>%
         summarise(export = sum(value, na.rm = T)),
       by = c("country", "partner")
@@ -212,7 +313,11 @@ to_flow_mat <- function(d) {
   return(flow_mat)
 }
 
-# "Netize" so that there is no A <-> B
+#' @title Netize
+#' @description "Netize" so that there is no A <-> B
+#' @param flow_matrix the flow matrix to netize
+#' @return the flow matrix with no A <-> B
+#' @rdname netize
 netize <- function(flow_matrix) {
   if (is.null(flow_matrix)) {
     stop("d is null")
@@ -236,64 +341,30 @@ netize <- function(flow_matrix) {
     select(-c(value_opposite))
 }
 
+#' @title Convert to data frame
+#' @description Converts a flow matrix to a data frame.
+#' @param flow_matrix the flow matrix to convert
+#' @return a data frame of flows
+#' @rdname convert_to_data_frame
+convert_to_data_frame <- function(flow_matrix) {
+  all_countries <- dimnames(flow_matrix)[[1]]
 
-distribute <- function(flow_matrix) {
-  # Considering each country as an importer, we proportionally distribute
-  # the indirect imports of gas to each provider ("neighbours" of importers)
-  # from sub-providers ("neighbours" of providers) directly to the importer.
-  #
-  # When this function is called iteratively, on the first iteration, the
-  # "neighbours" will be the actual neighbours in the gas system but on
-  # future iterations, these will also include the sub-providers and then
-  # the sub-provider's sub-providers (and so on).
-
-  production_for_countries <- diag(flow_matrix)
-
-  countries <- rownames(flow_matrix)
-
-  for (importer in countries) {
-    importer_production <- get_production_for_country(flow_matrix, importer)
-
-    # We will iteratively modify this in the for loop.
-    aggregate_imports <- importer_production
-
-    for (provider in countries) {
-      if (importer == provider) {
-        next
-      }
-
-      provider_to_importer <- flow_matrix[importer, provider]
-
-      providers_imports <- flow_matrix[provider, ]
-      # Ukraine special case: Ukraine cannot reimport gas from Russia
-      if ((importer == "UA")) {
-        providers_imports["RU"] <- 0
-      }
-
-
-      subprovider_attribution <- if (sum(providers_imports) > 0) {
-        provider_to_importer * providers_imports / sum(providers_imports)
-      } else {
-        0
-      }
-
-      aggregate_imports <- aggregate_imports + subprovider_attribution
-      # What was added needs to be removed, sort of
-      # by passing the original
-      flow_matrix[provider, ] <- flow_matrix[provider, ] - subprovider_attribution
-      flow_matrix[provider, provider] <- production_for_countries[provider]
-    }
-
-    flow_matrix[importer, ] <- aggregate_imports
-  }
-
-  return(flow_matrix)
+  return(
+    bind_cols(country = sort(all_countries), as.data.frame(flow_matrix)) %>%
+      gather(key = "from_country", value = "value", -country) %>%
+      rename(to_country = country)
+  )
 }
 
-verify_matrix <- function(current, original) {
-  # We use flow_mat to have consumption
-  without_production <- current - diag(diag(current))
-
+#' @title Verify matrix
+#' @description Verifies that a flow matrix is square and that the rownames and
+#' colnames are the same.
+#' @param current the matrix to verify
+#' @return the matrix which has been verified
+#' @details will stop if the matrix is not square or if the rownames and
+#' colnames are not the same
+#' @rdname verify_matrix
+verify_matrix <- function(current) {
   matrix_names_same <- all(rownames(current) == colnames(current))
   is_square <- is_matrix_square(current)
 
@@ -310,7 +381,13 @@ verify_matrix <- function(current, original) {
   return(current)
 }
 
-get_production_for_country <- function(flow_mat, country) {
+#' @title Get production for country
+#' @description Gets the production for a country from a flow matrix.
+#' @param flow_mat the flow matrix to get the production from
+#' @param country the country to get the production for
+#' @return a matrix containing only the production for the country
+#' @rdname get_production_matrix_for_country
+get_production_matrix_for_country <- function(flow_mat, country) {
   countries <- rownames(flow_mat)
 
   country_index <- which(dimnames(flow_mat)[[1]] == country)
@@ -320,6 +397,21 @@ get_production_for_country <- function(flow_mat, country) {
   return(country_production_only)
 }
 
+#' @title Is matrix square
+#' @description Checks if a matrix is square.
+#' @param mat the matrix to check
+#' @return TRUE if the matrix is square, FALSE otherwise
+#' @rdname is_matrix_square
 is_matrix_square <- function(mat) {
   dim(mat)[1] == dim(mat)[2]
+}
+
+#' @title Remove production
+#' @description Removes production from a flow matrix.
+#' @param flow_matrix the flow matrix to remove production from
+#' @return the flow matrix with production removed
+#' @rdname remove_production
+remove_production <- function(flow_matrix) {
+  diag(flow_matrix) <- 0
+  return(flow_matrix)
 }

--- a/R/source_entsog_new.R
+++ b/R/source_entsog_new.R
@@ -3,42 +3,20 @@ entsog_new.get_flows <- function(date_from = "2021-11-01", date_to = NULL, use_c
     date_to <- as.character(lubridate::today() + lubridate::days(1))
   }
 
-  years <- seq(lubridate::year(date_from), lubridate::year(date_to))
+  flows <- entsog_new.get_flows_for_period(date_from, date_to) %>%
+    entsog_new.format_flows()
 
-  flows <- lapply(years, function(year) {
-    date_from_ <- max(as.Date(date_from), as.Date(paste0(year, "-01-01")))
-    date_to_ <- min(as.Date(date_to), as.Date(paste0(year, "-12-31")))
-    read_csv(sprintf(
-      "https://api.russiafossiltracker.com/v0/entsogflow?type=crossborder,production&format=csv&date_from=%s&date_to=%s",
-      date_from_, date_to_
-    ))
-  }) %>%
-    bind_rows()
+  flows_sourced <- process_iterative(flows)
 
-  flows <- flows %>% filter(destination_iso2 != "RU")
-
-  flows_formatted <- flows %>%
-    select(
-      from_country = commodity_origin_iso2,
-      to_country = commodity_destination_iso2,
-      date,
-      value = value_m3
-    )
-
-  flows_sourced <- process_iterative(flows_formatted)
-
-  sum(flows_sourced$value[flows_sourced$from_country == "RU"], na.rm = T) / 1e9
-  sum(flows_formatted$value[flows_formatted$from_country == "RU"]) / 1e9
-  sum(flows_sourced$value[flows_sourced$from_country == flows_sourced$to_country], na.rm = T) / 1e9 == 0
+  message(entsog_new.print_stats(flows, flows_sourced))
 
   # Add production
   flows_sourced <- bind_rows(
     flows_sourced %>%
       filter(from_country != to_country),
-    flows_formatted %>%
+    flows %>%
       filter(from_country == to_country)
   )
-
 
   flows_sourced <- flows_sourced %>%
     mutate(value = round(value, 2)) %>% # Some values are ~-1e-15
@@ -52,4 +30,47 @@ entsog_new.get_flows <- function(date_from = "2021-11-01", date_to = NULL, use_c
     )
 
   return(flows_sourced)
+}
+
+entsog_new.get_flows_for_period <- function(date_from, date_to) {
+  years <- seq(lubridate::year(date_from), lubridate::year(date_to))
+
+  flows <- lapply(years, function(year) {
+    entsog_new.get_flows_for_year(year, date_from, date_to)
+  }) %>%
+    bind_rows()
+
+  return(
+    flows %>%
+      filter(destination_iso2 != "RU")
+  )
+}
+
+entsog_new.get_flows_for_year <- function(year, date_from, date_to) {
+  date_from_ <- max(as.Date(date_from), as.Date(paste0(year, "-01-01")))
+  date_to_ <- min(as.Date(date_to), as.Date(paste0(year, "-12-31")))
+  return(
+    read_csv(sprintf(
+      "https://api.russiafossiltracker.com/v0/entsogflow?type=crossborder,production&format=csv&date_from=%s&date_to=%s",
+      date_from_, date_to_
+    ))
+  )
+}
+
+entsog_new.format_flows <- function(flows) {
+  return(
+    flows %>%
+      select(
+        from_country = commodity_origin_iso2,
+        to_country = commodity_destination_iso2,
+        date,
+        value = value_m3
+      )
+  )
+}
+
+entsog_new.print_stats <- function(flows, flows_sourced) {
+  sum(flows_sourced$value[flows_sourced$from_country == "RU"], na.rm = T) / 1e9
+  sum(flows$value[flows$from_country == "RU"]) / 1e9
+  sum(flows_sourced$value[flows_sourced$from_country == flows_sourced$to_country], na.rm = T) / 1e9 == 0
 }


### PR DESCRIPTION
 - [`8eec2f8`](https://github.com/energyandcleanair/fossil_shipment_tracker_r/pull/2/commits/8eec2f87e920f6fd9d549cc0390253ff5de8fdec): Improves the code quality for the model and adds tests to cover various cases.
 - [`8c75d0f`](https://github.com/energyandcleanair/fossil_shipment_tracker_r/pull/2/commits/8c75d0f94eb053618c4a17dde49251c48d42d95e): Improves the code quality for the wrapper to make it easier to add the new functionality.
 - [`b536ef7`](https://github.com/energyandcleanair/fossil_shipment_tracker_r/pull/2/commits/b536ef72999345817b68b1d87f611d9fdc7d7792): Adds new tests and, for each day of the analysis, uses the moving average of the previous 90 days before to bypass.

What moving average should we take to calculate the bypass? From the below charts, we have seasonality.

## Are the imports to MK, RO, and RS seasonal?

![seasonality](https://github.com/energyandcleanair/fossil_shipment_tracker_r/assets/13658288/9260144c-6e5e-4b6c-a4e7-1c04079cd468)

Yes. There is a clear seasonal trend for most of the countries.

## Comparison of models
![entsog_comparison_chart](https://github.com/energyandcleanair/fossil_shipment_tracker_r/assets/13658288/05651079-14a7-4983-8e5a-ef972e34f99f)
